### PR TITLE
initramfs checks 2 places for rootfs (issue #621)

### DIFF
--- a/meta-hp/recipes-core/initrdscripts/initramfs-boot-android/init-tenderloin.sh
+++ b/meta-hp/recipes-core/initrdscripts/initramfs-boot-android/init-tenderloin.sh
@@ -14,6 +14,26 @@ fail() {
     reboot
 }
 
+mount_rootfs() {
+    ROOT="$1"
+
+    if [ -b /dev/store/$ROOT ] 
+    then
+        info "Found $ROOT volume"
+        mount /dev/store/$ROOT /rfs 
+        if [ -e /rfs/etc/webos-release ]
+        then
+          info "Using $ROOT as rootfs"
+          return 0 # success
+        else
+          info "Volume $ROOT does not contain LuneOS rootfs"
+          umount /rfs
+        fi
+    fi
+    
+    return 1 # failure
+}
+
 setup_devtmpfs() {
     # mount -t devtmpfs -o mode=0755,nr_inodes=0 devtmpfs $1/dev
     mount -t devtmpfs devtmpfs $1/dev
@@ -48,8 +68,9 @@ then
    fail "Failed to start LVM"
 fi
 
+# look for "luneos-root" volume, with generic "ext3fs" volume as fallback
 mkdir -m 0755 /rfs
-mount /dev/store/ext3fs /rfs
+mount_rootfs luneos-root || mount_rootfs ext3fs || fail "Failed to mount root"
 
 info "Done mounting rootfs!"
 

--- a/meta-hp/recipes-core/initrdscripts/initramfs-boot-android/init-tenderloin.sh
+++ b/meta-hp/recipes-core/initrdscripts/initramfs-boot-android/init-tenderloin.sh
@@ -21,12 +21,15 @@ mount_rootfs() {
     then
         info "Found $ROOT volume"
         mount /dev/store/$ROOT /rfs 
-        if [ -e /rfs/etc/webos-release ]
+        # sanity-check rootfs by checking that specific path exists
+        # (automatic pass if distro_rootfs_file is unset, since /rfs/
+        # mountpoint does exist)
+        if [ -e /rfs/${distro_rootfs_file} ]
         then
           info "Using $ROOT as rootfs"
           return 0 # success
         else
-          info "Volume $ROOT does not contain LuneOS rootfs"
+          info "Volume $ROOT does not contain rootfs"
           umount /rfs
         fi
     fi
@@ -68,9 +71,9 @@ then
    fail "Failed to start LVM"
 fi
 
-# look for "luneos-root" volume, with generic "ext3fs" volume as fallback
+# look for distro-specific volume, with generic "ext3fs" volume as fallback
 mkdir -m 0755 /rfs
-mount_rootfs luneos-root || mount_rootfs ext3fs || fail "Failed to mount root"
+mount_rootfs ${distro_name}-root || mount_rootfs ext3fs || fail "Failed to mount root"
 
 info "Done mounting rootfs!"
 


### PR DESCRIPTION
http://issues.webos-ports.org/issues/621

When installing LuneOS, the generic volume "ext3fs" may already contain
something else, so there should be an alternate install procedure allowing
use of a more uniquely named volume, i.e. "luneos-root".

Prepare for such installs by having the initramfs script check first
for "luneos-root" and then fall back to "ext3fs" when trying to mount root.
Each candidate root is sanity-checked by looking for existence of
/etc/webos-release before picking it for switchroot.

Signed-off-by: S. Lockwood-Childs sjl@vctlabs.com
