### PR TITLE
Create bluetooth HCI (Host Controller Interface)

### DIFF
--- a/meta-lg/recipes-core/systemd/systemd-machine-units/mako/hci-smd-enable.sh
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units/mako/hci-smd-enable.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#Do android specific init requirement first
+setprop bluetooth.hciattach true
+
+#Maximum number of attempts to try and init 
+#the hci device. 
+max_retries=10 
+
+for idx in $(seq 1 ${max_retries}); do 
+	echo 1 > /sys/module/hci_smd/parameters/hcismd_set 
+	if [ -e /sys/class/bluetooth/hci0 ] ;then
+		#hci device has been initialized
+		exit 0 
+	fi
+	sleep 1 
+done 
+
+#max retries exhausted. Something is wrong
+exit 1 

--- a/meta-lg/recipes-core/systemd/systemd-machine-units/mako/hcismd.service
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units/mako/hcismd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Enable Bluetooth HCI SMD device
+DefaultDependencies=false
+Requires=android-system.service
+After=android-system.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/hci-smd-enable.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=bluetooth.service

--- a/meta-lg/recipes-core/systemd/systemd-machine-units_1.0.bbappend
+++ b/meta-lg/recipes-core/systemd/systemd-machine-units_1.0.bbappend
@@ -3,14 +3,21 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append_mako = " \
     file://wifi-macaddr-persister.service \
     file://persist-wifi-mac-addr.sh \
+    file://hcismd.service \
+    file://hci-smd-enable.sh \
 "
 
 do_install_append_mako() {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/wifi-macaddr-persister.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/hcismd.service ${D}${systemd_unitdir}/system
 
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/persist-wifi-mac-addr.sh ${D}${bindir}
+    install -m 0755 ${WORKDIR}/hci-smd-enable.sh ${D}${bindir}
 }
 
-SYSTEMD_SERVICE_${PN}_mako = "wifi-macaddr-persister.service"
+SYSTEMD_SERVICE_${PN}_mako = " \
+    wifi-macaddr-persister.service \
+    hcismd.service \
+"


### PR DESCRIPTION
SMD device link on bluetooth bringup. If bluetooth-service
is enabled  for boot-time (ie systemctl enable bluetooth),
then this is done automatically ;
otherwise a systemctl start bluetooth is required

Signed-off-by: Dejice Jacob <dejicejacob@yahoo.co.in>